### PR TITLE
[WORK IN PROGRESS] Added initial compatibility for XT3

### DIFF
--- a/lupupy/__init__.py
+++ b/lupupy/__init__.py
@@ -33,11 +33,13 @@ class Lupusec():
             self.mode_translation = {'Disarm': 2, 'Home': 1, 'Arm': 0}
             self.key_mode = 'mode_st'
             self.key_sensors = 'sensorListGet'
+            self.key_device_id = 'no'
             self._request_post('login')
         elif model == 'xt3':
             self.mode_translation = {'Disarm': 0, 'Arm': 1, 'Home': 2}
             self.key_mode = 'mode_a1'  # Could also be mode_a2 for area 2. TODO: Needs to be made configurable
             self.key_sensors = 'deviceListGet'
+            self.key_device_id = 'sid'
 
             # On XT3, we need to get a token that will be sent which each request
             token_response = self._request_get('tokenGet')  # Example response: {"result" : 1, "message" : "..."}
@@ -116,13 +118,9 @@ class Lupusec():
             sensors = []
             for device in response:
                 device['status'] = device['cond']
-                if self.model == 'xt1':
-                    device['device_id'] = device['no']
-                    device.pop('no')
-                if self.model == 'xt3':
-                    device['device_id'] = device['sid']
-                    device.pop('sid')
+                device['device_id'] = device[self.key_device_id]
                 device.pop('cond')
+                device.pop(self.key_device_id)
                 if not device['status']:
                     device['status'] = 'Geschlossen'
                 else:

--- a/lupupy/__init__.py
+++ b/lupupy/__init__.py
@@ -19,14 +19,33 @@ home = str(Path.home())
 class Lupusec():
     """Interface to Lupusec Webservices."""
 
-    def __init__(self, username, password, ip_address, get_devices=False):
+    def __init__(self, username, password, ip_address, model="xt1", get_devices=False):
         """LupsecAPI constructor requires IP and credentials to the
          Lupusec Webinterface.
         """
         self.session = requests.Session()
         self.session.auth = (username, password)
         self.api_url = "http://{}/action/".format(ip_address)
-        self._request_post('login')
+        self.model = model
+        self.headers = None
+
+        if model == 'xt1':
+            self.mode_translation = {'Disarm': 2, 'Home': 1, 'Arm': 0}
+            self.key_mode = 'mode_st'
+            self.key_sensors = 'sensorListGet'
+            self._request_post('login')
+        elif model == 'xt3':
+            self.mode_translation = {'Disarm': 0, 'Arm': 1, 'Home': 2}
+            self.key_mode = 'mode_a1'  # Could also be mode_a2 for area 2. TODO: Needs to be made configurable
+            self.key_sensors = 'deviceListGet'
+
+            # On XT3, we need to get a token that will be sent which each request
+            token_response = self._request_get('tokenGet')  # Example response: {"result" : 1, "message" : "..."}
+            token = self.clean_json(token_response.text)['message']
+            self.headers = {"X-Token": token}
+            # TODO: add method to refresh token when it expires
+        else:
+            raise Exception("Unsupported model")
 
         self._mode = None
         self._devices = None
@@ -43,23 +62,24 @@ class Lupusec():
         self._cachePss = None
         self._cacheStampP = time.time()
 
-        if get_devices or self._devices == None:
+        if get_devices or self._devices is None:
             self.get_devices()
 
     def _request_get(self, action):
-        response = self.session.get(self.api_url + action, timeout=15)
+        response = self.session.get(self.api_url + action, timeout=15, headers=self.headers)
         _LOGGER.debug('Action and statuscode of apiGET command: %s, %s',
                       action, response.status_code)
         return response
 
     def _request_post(self, action, params={}):
-        return self.session.post(self.api_url + action, data=params)
+        return self.session.post(self.api_url + action, data=params, headers=self.headers)
 
     def clean_json(self, textdata):
         _LOGGER.debug('Input for clean json' + textdata)
         textdata = textdata.replace("\t", "")
         i = textdata.index('\n')
-        textdata = textdata[i+1:-2]
+        if self.model == 'xt1':
+            textdata = textdata[i+1:-2]
         textdata = demjson.decode(textdata)
         return textdata
 
@@ -91,14 +111,18 @@ class Lupusec():
         stamp_now = time.time()
         if self._cacheSensors is None or stamp_now - self._cacheStampS > 2.0:
             self._cacheStampS = stamp_now
-            response = self._request_get('sensorListGet')
+            response = self._request_get(self.key_sensors)
             response = self.clean_json(response.text)['senrows']
             sensors = []
             for device in response:
                 device['status'] = device['cond']
-                device['device_id'] = device['no']
+                if self.model == 'xt1':
+                    device['device_id'] = device['no']
+                    device.pop('no')
+                if self.model == 'xt3':
+                    device['device_id'] = device['sid']
+                    device.pop('sid')
                 device.pop('cond')
-                device.pop('no')
                 if not device['status']:
                     device['status'] = 'Geschlossen'
                 else:
@@ -114,20 +138,28 @@ class Lupusec():
             print(response.text)
             raise Exception('Unable to get panel')
         panel = self.clean_json(response.text)['updates']
-        panel['mode'] = panel['mode_st']
-        panel.pop('mode_st')
+        panel['mode'] = panel[self.key_mode]
+        panel.pop(self.key_mode)
+
+        # XT3 uses different namings for the modes. "Translate" them to the ones used everywhere else in this module.
+        # TODO: This needs a cleaner solution
+        if self.model == 'xt3':
+            panel['mode'] = CONST.XT3_MODES_TO_TEXT[panel['mode']]
+
         panel['device_id'] = CONST.ALARM_DEVICE_ID
         panel['type'] = CONST.ALARM_TYPE
         panel['name'] = CONST.ALARM_NAME
 
         history = self.get_history()
 
-        for histrow in history:
-            if histrow not in self._history_cache:
-                if CONST.MODE_ALARM_TRIGGERED in histrow[CONST.HISTORY_ALARM_COLUMN]:
-                    panel['mode'] = CONST.STATE_ALARM_TRIGGERED
-                self._history_cache.append(histrow)
-                pickle.dump(self._history_cache, open(home + "/" + CONST.HISTORY_CACHE_NAME, "wb"))
+        # TODO: add compatibility for XT3
+        if self.model == 'xt1':
+            for histrow in history:
+                if histrow not in self._history_cache:
+                    if CONST.MODE_ALARM_TRIGGERED in histrow[CONST.HISTORY_ALARM_COLUMN]:
+                        panel['mode'] = CONST.STATE_ALARM_TRIGGERED
+                    self._history_cache.append(histrow)
+                    pickle.dump(self._history_cache, open(home + "/" + CONST.HISTORY_CACHE_NAME, "wb"))
 
         return panel
 
@@ -181,24 +213,25 @@ class Lupusec():
                 alarmDevice = ALARM.create_alarm(panelJson, self)
                 self._devices['0'] = alarmDevice
 
-            # Now we will handle the power switches
-            switches = self.get_power_switches()
-            _LOGGER.debug(
-                'Get active the power switches in get_devices: %s', switches)
+            # Now we will handle the power switches (only for XT1, as switches are already in the feed with the sensors)
+            if self.model == 'xt1':
+                switches = self.get_power_switches()
+                _LOGGER.debug(
+                    'Get active the power switches in get_devices: %s', switches)
 
-            for deviceJson in switches:
-                # Attempt to reuse an existing device
-                device = self._devices.get(deviceJson['name'])
+                for deviceJson in switches:
+                    # Attempt to reuse an existing device
+                    device = self._devices.get(deviceJson['name'])
 
-                # No existing device, create a new one
-                if device:
-                    device.update(deviceJson)
-                else:
-                    device = newDevice(deviceJson, self)
-                    if not device:
-                        _LOGGER.info('Device is unknown')
-                        continue
-                    self._devices[device.device_id] = device
+                    # No existing device, create a new one
+                    if device:
+                        device.update(deviceJson)
+                    else:
+                        device = newDevice(deviceJson, self)
+                        if not device:
+                            _LOGGER.info('Device is unknown')
+                            continue
+                        self._devices[device.device_id] = device
 
         if generic_type:
             devices = []
@@ -232,11 +265,18 @@ class Lupusec():
         return self.get_device(CONST.ALARM_DEVICE_ID, refresh)
 
     def set_mode(self, mode):
-        r = self._request_post(
-            "panelCondPost",
-            {
+        if self.model == 'xt1':
+            params = {
                 'mode': mode,
             }
+        elif self.model == 'xt3':
+            params = {
+                'mode': mode,
+                'area': 1  # TODO: Needs to be made configurable
+            }
+        r = self._request_post(
+            "panelCondPost",
+            params
         )
         responseJson = self.clean_json(r.text)
         return responseJson

--- a/lupupy/__main__.py
+++ b/lupupy/__main__.py
@@ -43,6 +43,11 @@ def get_arguments():
     parser = argparse.ArgumentParser("Lupupy: Command Line Utility")
 
     parser.add_argument(
+        '-m', '--model',
+        help='Model',
+        required=False, choices=['xt1', 'xt3'], default='xt1')
+
+    parser.add_argument(
         '-u', '--username',
         help='Username',
         required=False)
@@ -124,7 +129,7 @@ def call():
         if args.username and args.password and args.ip_address:
             lupusec = lupupy.Lupusec(ip_address=args.ip_address,
                                      username=args.username,
-                                     password=args.password)
+                                     password=args.password, model=args.model)
         
         if args.arm:
             if lupusec.get_alarm().set_away():

--- a/lupupy/constants.py
+++ b/lupupy/constants.py
@@ -17,7 +17,14 @@ MODE_HOME = 'Home'
 MODE_DISARMED = 'Disarm'
 MODE_ALARM_TRIGGERED = 'Einbruch'
 ALL_MODES = [MODE_DISARMED, MODE_HOME, MODE_AWAY]
-MODE_TRANSLATION = {'Disarm' : 2, 'Home' : 1, 'Arm' : 0}
+
+XT3_MODES_TO_TEXT = {
+    '{AREA_MODE_0}': 'Disarm',
+    '{AREA_MODE_1}': 'Arm',
+    '{AREA_MODE_2}': 'Home',
+    '{AREA_MODE_3}': 'Home',
+    '{AREA_MODE_4}': 'Home'
+}
 
 STATE_ALARM_DISARMED = 'disarmed'
 STATE_ALARM_ARMED_HOME = 'armed_home'
@@ -48,9 +55,21 @@ ALARM_TYPE = 'Alarm'
 # GENERIC Lupusec DEVICE TYPES
 TYPE_WINDOW = "Fensterkontakt"
 TYPE_DOOR = "Türkontakt"
+TYPE_CONTACT_XT3 = 4
+TYPE_WATER_XT3 = 5
+# TYPE_MOTION_SENSOR_XT3 = 9
+TYPE_SMOKE_XT3 = 11
+TYPE_POWER_SWITCH_1_XT3 = 24
+TYPE_POWER_SWITCH_2_XT3 = 25
 TYPE_POWER_SWITCH = 'Steckdose'
-TYPE_SWITCH = [TYPE_POWER_SWITCH]
-TYPE_OPENING = [TYPE_DOOR, TYPE_WINDOW]
+TYPE_SWITCH = [TYPE_POWER_SWITCH, TYPE_POWER_SWITCH_1_XT3, TYPE_POWER_SWITCH_2_XT3]
+TYPE_OPENING = [TYPE_DOOR, TYPE_WINDOW, TYPE_CONTACT_XT3]
 BINARY_SENSOR_TYPES = TYPE_OPENING
-TYPE_SENSOR = ['Rauchmelder', 'Wassermelder']
-TYPE_TRANSLATION = {'Fensterkontakt' : 'window', 'Türkontakt' : 'door'}
+TYPE_SENSOR = ['Rauchmelder', 'Wassermelder', TYPE_WATER_XT3, TYPE_SMOKE_XT3]
+TYPE_TRANSLATION = {
+    'Fensterkontakt': 'window',
+    'Türkontakt': 'door',
+    TYPE_CONTACT_XT3: 'Fenster-/Türkontakt',
+    TYPE_WATER_XT3: 'Wassermelder',
+    TYPE_SMOKE_XT3: 'Rauchmelder',
+}

--- a/lupupy/devices/__init__.py
+++ b/lupupy/devices/__init__.py
@@ -23,7 +23,8 @@ class LupusecDevice(object):
         self._lupusec = lupusec
 
         if not self._name:
-            self._name = self.type + ' ' + self.device_id
+            # In a previous version, type was used instead of _generic_type, but on XT3 type is an integer
+            self._name = self._generic_type + ' ' + self.device_id
 
     def get_value(self, name):
         """Get a value from the json object.

--- a/lupupy/devices/alarm.py
+++ b/lupupy/devices/alarm.py
@@ -28,7 +28,7 @@ class LupusecAlarm(LupusecSwitch):
             _LOGGER.info('No mode supplied')
         elif mode not in CONST.ALL_MODES:
             _LOGGER.warning('Invalid mode')
-        response_object = self._lupusec.set_mode(CONST.MODE_TRANSLATION[mode])
+        response_object = self._lupusec.set_mode(self._lupusec.mode_translation[mode])
         if response_object['result'] != 1:
             _LOGGER.warning('Mode setting unsuccessful')
 


### PR DESCRIPTION
Work in Progress. Do note merge yet.

I added initial compatibility for XT3.
The goal was to change as less code as possible, in order to keep the XT1 compatibility intact. I added an additional argument "--model" to the command line and an additional "model" argument to the Lupusec.__init__ method. Accepted values are "xt1" (default) or "xt3".

A few constants were converted to variables (e.g. MODE_TRANSLATION) because they are different for each device. Apart from that, only a few "if"-statements were needed throughout the code.

What works so far:
- reading the sensors and their status
- reading the panel mode (disarm, arm, home)
- setting the panel mode (disarm, arm, home)
- command line access

What doesn't work:
- So far only area 1 is supported. If you've configured multiple areas, you currently won't be able to use them.
- Home Assistant integration is yet to be tested.
- I can't test the power switches functionality as I don't have any.
- Detecting an alarm (through the "history" of the panel).

I can only work on this during the weekends, so not sure when I'll be able to finalize the implementation, but I still wanted to publish the current status in case anybody wanted to join in.