### PR TITLE
fix: get_devices only checks for the first type

### DIFF
--- a/lupupy/__init__.py
+++ b/lupupy/__init__.py
@@ -312,7 +312,7 @@ class Lupusec:
         if generic_type:
             devices = []
             for device in self._devices.values():
-                if device.type is not None and device.type in generic_type[0]:
+                if device.type is not None and device.type in generic_type:
                     devices.append(device)
             return devices
 


### PR DESCRIPTION
When testing this in Homeassistant with an XT2 Plus, i noticed, that the get_devices() function checks the type by checking if the type is found in the parameter generic_type. But for this to work and check for the type ids used in XT2 etc, we need to fix this to not only check for the first entry in the passed list.

Otherwise Homeassistant throws the following error:
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 304, in _async_setup_platform
    await asyncio.shield(task)
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/components/lupusec/switch.py", line 33, in setup_platform
    for device in data.lupusec.get_devices(generic_type=CONST.TYPE_SWITCH):
  File "/usr/local/lib/python3.10/site-packages/lupupy/__init__.py", line 315, in get_devices
    if device.type is not None and device.type in generic_type[0]:
TypeError: 'in <string>' requires string as left operand, not int
```

When this is merged, we also need to update the homeassistant integration part, since there are parts where the parameter is passed in a wrong / inconsistent way.

Thank you for your work!