### PR TITLE
Fix SyntaxWarning comparison with literal

### DIFF
--- a/lupupy/devices/alarm.py
+++ b/lupupy/devices/alarm.py
@@ -29,7 +29,7 @@ class LupusecAlarm(LupusecSwitch):
         elif mode not in CONST.ALL_MODES:
             _LOGGER.warning("Invalid mode")
         response_object = self._lupusec.set_mode(self._lupusec.mode_translation[mode])
-        if response_object["result"] != 1 and response_object["result"] is not "1":
+        if response_object["result"] != 1 and response_object["result"] != "1":
             _LOGGER.warning("Mode setting unsuccessful")
 
         self._json_state["mode"] = mode


### PR DESCRIPTION
```
  /.../lupupy/devices/alarm.py:32: SyntaxWarning: "is not" with a literal. Did you mean "!="?
    if response_object["result"] != 1 and response_object["result"] is not "1":
```